### PR TITLE
fix-redraw mask

### DIFF
--- a/src/SingleCellAnnotator.imjoy.html
+++ b/src/SingleCellAnnotator.imjoy.html
@@ -589,7 +589,10 @@ const app = new Vue({
         this.stopMaskAnnotation()
       }
       if(this.draw_mask_mode && !imageData.extended){
-        this.extendImage()
+        const location = this.current_image_data.location;
+        await this.extendImage();
+        this.current_image_data.location = location;
+        this.current_image_data.redraw_mask_occurred = true;
       }
       else{
         this.$nextTick(async ()=>{

--- a/src/SingleCellAnnotator.imjoy.html
+++ b/src/SingleCellAnnotator.imjoy.html
@@ -161,6 +161,7 @@ async function composeChannels(channels, channel_settings, alpha, brightness){
 }
 
 const imageDataTemplate = {
+  redraw_mask_occurred: false,
   extend: null,
   cell_id: null,
   mask_geojson:{
@@ -690,7 +691,12 @@ const app = new Vue({
         this.loading = true;
         try{
           this.current_image_data.mask_adjusted=false;
-          await this.extendImage();
+          if(!this.current_image_data.redraw_mask_occurred){
+            const location = this.current_image_data.location;
+            await this.extendImage();
+            this.current_image_data.location = location;
+            this.current_image_data.redraw_mask_occurred = true;
+          }
         }
         finally{
           this.loading = false;


### PR DESCRIPTION
This fix can

1. if ever redraw mask, if readjust the image, will use the extended image from cached instead of reloading
2. if first time to readjust mask, it will load extended image but load the location info, instead of location of null from backend