### PR TITLE
Fix openlayers URL

### DIFF
--- a/src/MNReannotator.imjoy.html
+++ b/src/MNReannotator.imjoy.html
@@ -21,8 +21,8 @@
         "https://static.imjoy.io/spectre.css/spectre.min.css",
         "https://static.imjoy.io/spectre.css/spectre-exp.min.css",
         "https://static.imjoy.io/spectre.css/spectre-icons.min.css",
-        "https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.1.1/css/ol.css",
-        "https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.1.1/build/ol.js",
+        "https://openlayers.org/en/v6.1.1/css/ol.css",
+        "https://openlayers.org/en/v6.1.1/build/ol.js",
         "https://www.gstatic.com/charts/loader.js",
         "https://www.google.com/jsapi"
     ],


### PR DESCRIPTION
@cwinsnes The plugin fails because of some URLs to the openlayers libraries were broken, I have updated the links.